### PR TITLE
RENAMED PLUGIN

### DIFF
--- a/lib/commandoes_activemodel/plugins/validations_plugin.rb
+++ b/lib/commandoes_activemodel/plugins/validations_plugin.rb
@@ -1,6 +1,6 @@
 module Commandoes
   module Plugins
-    module ActiveModelValidationsPlugin
+    module ActiveModelPlugin
       module ClassMethods
         def self.extended(object)
           object.send(:include, ActiveModel::Validations)

--- a/test/fixtures/fake_command.rb
+++ b/test/fixtures/fake_command.rb
@@ -1,6 +1,6 @@
 module Commandoes
   class FakeCommand < Commandoes::IAmACommand
-    use Commandoes::Plugins::ActiveModelValidationsPlugin
+    use Commandoes::Plugins::ActiveModelPlugin
 
     attr_reader :name
     attr_reader :value


### PR DESCRIPTION
Renamed the `Commandoes::Plugins::ActiveModelValidations` plugin to
`Commandoes::Plugins::ActiveModelPlugin`